### PR TITLE
Add note of caution to performance ratios and uncomment tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -116,6 +116,6 @@ jobs:
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
-          body: "Performance Ratio:\n```\n${{ steps.read-file.outputs.table }}\n```"
+          body: "Performance Ratio:\nWarning: results are very approximate!\n```\n${{ steps.read-file.outputs.table }}\n```"
           comment-id: ${{ steps.fc.outputs.comment-id }}
           edit-mode: replace

--- a/src/rrules/builtins.jl
+++ b/src/rrules/builtins.jl
@@ -674,7 +674,6 @@ function rrule!!(f::CoDual{typeof(typeof)}, x::CoDual)
 end
 
 function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:builtins})
-    return Any[], Any[]
 
     _x = Ref(5.0) # data used in tests which aren't protected by GC.
     _dx = Ref(4.0)


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Tapir.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
The performance ratios will differ a lot depending on where you run them. Add a note to tell people to be cautious.

edit: additionally, in a previous PR, I had accidentally deactivated a large number of tests that really ought not to have been deactivated. Revert that.