### PR TITLE
Make getfield on tasks work

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tapir"
 uuid = "07d77754-e150-4737-8c94-cd238a1fb45b"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.2.22"
+version = "0.2.23"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/Tapir.jl
+++ b/src/Tapir.jl
@@ -83,6 +83,7 @@ include(joinpath("rrules", "lapack.jl"))
 include(joinpath("rrules", "low_level_maths.jl"))
 include(joinpath("rrules", "misc.jl"))
 include(joinpath("rrules", "new.jl"))
+include(joinpath("rrules", "tasks.jl"))
 
 include("chain_rules_macro.jl")
 include("interface.jl")

--- a/src/fwds_rvs_data.jl
+++ b/src/fwds_rvs_data.jl
@@ -206,6 +206,12 @@ function _verify_fdata_value(p::Array, f::Array)
     return nothing
 end
 
+# (mutable) structs, Tuples, and NamedTuples all have slightly different storage.
+_get_fdata_field(f::NamedTuple, name) = getfield(f, name)
+_get_fdata_field(f::Tuple, name) = getfield(f, name)
+_get_fdata_field(f::FData, name) = val(getfield(f.data, name))
+_get_fdata_field(f::MutableTangent, name) = fdata(val(getfield(f.fields, name)))
+
 function _verify_fdata_value(p, f)
 
     # If f is a NoFData then there are no checks needed, because we have already verified
@@ -217,12 +223,6 @@ function _verify_fdata_value(p, f)
     # The rest of this method assumes p is an instance of a struct type, so we must error.
     P = _typeof(p)
     isprimitivetype(P) && error("Encountered primitive $p with fdata $f")
-
-    # (mutable) structs, Tuples, and NamedTuples all have slightly different storage.
-    _get_fdata_field(f::NamedTuple, name) = getfield(f, name)
-    _get_fdata_field(f::Tuple, name) = getfield(f, name)
-    _get_fdata_field(f::FData, name) = val(getfield(f.data, name))
-    _get_fdata_field(f::MutableTangent, name) = fdata(val(getfield(f.fields, name)))
 
     # Having excluded primitive types, we must have a (mutable) struct type. Recurse into
     # its fields and verify each of them.

--- a/src/rrules/misc.jl
+++ b/src/rrules/misc.jl
@@ -144,7 +144,8 @@ lsetfield!(value, ::Val{name}, x) where {name} = setfield!(value, name, x)
     old_dx = if F == NoFData
         NoFData()
     else
-        save ? val(getfield(tangent(value).fields, name)) : nothing
+        save ? get_tangent_field(tangent(value), name) : nothing
+        # save ? val(getfield(tangent(value).fields, name)) : nothing
     end
     dvalue = tangent(value)
     pb!! = if F == NoFData
@@ -154,7 +155,7 @@ lsetfield!(value, ::Val{name}, x) where {name} = setfield!(value, name, x)
         end
     else
         function setfield!_pullback(dy)
-            new_dx = increment!!(dy, rdata(val(getfield(dvalue.fields, name))))
+            new_dx = increment!!(dy, rdata(get_tangent_field(dvalue, name)))
             old_x !== nothing && lsetfield!(primal(value), Val(name), old_x)
             old_x !== nothing && set_tangent_field!(dvalue, name, old_dx)
             return NoRData(), NoRData(), NoRData(), new_dx

--- a/src/rrules/misc.jl
+++ b/src/rrules/misc.jl
@@ -145,7 +145,6 @@ lsetfield!(value, ::Val{name}, x) where {name} = setfield!(value, name, x)
         NoFData()
     else
         save ? get_tangent_field(tangent(value), name) : nothing
-        # save ? val(getfield(tangent(value).fields, name)) : nothing
     end
     dvalue = tangent(value)
     pb!! = if F == NoFData

--- a/src/rrules/tasks.jl
+++ b/src/rrules/tasks.jl
@@ -27,67 +27,6 @@ _scale(::Float64, t::TaskTangent) = t
 
 TestUtils.populate_address_map!(m::TestUtils.AddressMap, ::Task, ::TaskTangent) = m
 
-# function zero_tangent(p::Task)
-#     return TaskTangent(
-#         zero_tangent(p.next),
-#         zero_tangent(p.queue),
-#         zero_tangent(p.storage),
-#         zero_tangent(p.donenotify),
-#         zero_tangent(p.result),
-#         zero_tangent(p.logstate),
-#         zero_tangent(p.code),
-#         ntuple(n -> NoTangent(), 9)...,
-#     )
-# end
-
-# function randn_tangent(rng::AbstractRNG, p::Task)
-#     return TaskTangent(
-#         randn_tangent(rng, p.next),
-#         randn_tangent(rng, p.queue),
-#         randn_tangent(rng, p.storage),
-#         randn_tangent(rng, p.donenotify),
-#         randn_tangent(rng, p.result),
-#         randn_tangent(rng, p.logstate),
-#         randn_tangent(rng, p.code),
-#         ntuple(n -> NoTangent(), 9)...,
-#     )
-# end
-
-# function increment!!(t::TaskTangent, s::TaskTangent)
-#     t === s && return t
-#     t.next = increment!!(t.next, s.next)
-#     t.queue = increment!!(t.queue, s.queue)
-#     t.storage = increment!!(t.storage, s.storage)
-#     t.donenotify = increment!!(t.donenotify, s.donenotify)
-#     t.result = increment!!(t.result, s.result)
-#     t.logstate = increment!!(t.logstate, s.logstate)
-#     t.code = increment!!(t.code, s.code)
-#     return t
-# end
-
-# function set_to_zero!!(t::TaskTangent)
-#     t.next = set_to_zero!!(t.next)
-#     t.queue = set_to_zero!!(t.queue)
-#     t.storage = set_to_zero!!(t.storage)
-#     t.donenotify = set_to_zero!!(t.donenotify)
-#     t.result = set_to_zero!!(t.result)
-#     t.logstate = set_to_zero!!(t.logstate)
-#     t.code = set_to_zero!!(t.code)
-#     return t
-# end
-
-# function _add_to_primal(p::Task, t::TaskTangent)
-#     p.next = _add_to_primal(p.next, t.next)
-#     p.queue = _add_to_primal(p.queue, t.queue)
-#     p.storage = _add_to_primal(p.storage, t.storage)
-#     p.donenotify = _add_to_primal(p.donenotify, t.donenotify)
-#     p.result = _add_to_primal(p.result, t.result)
-#     p.logstate = _add_to_primal(p.logstate, t.logstate)
-#     p.code = _add_to_primal(p.code, t.code)
-#     return p
-# end
-
-
 fdata_type(::Type{TaskTangent}) = TaskTangent
 
 rdata_type(::Type{TaskTangent}) = NoRData

--- a/src/rrules/tasks.jl
+++ b/src/rrules/tasks.jl
@@ -1,0 +1,146 @@
+# Tasks are recursively-defined, so their tangent type needs to be done manually.
+# Occassionally one encountered tasks in code, but they don't actually get called. For
+# example, calls to `rand` with a `TaskLocalRNG` will query the local task, purely for the
+# sake of getting random number generator state associated to it.
+# The goal of the code in this file is to ensure that this kind of usage of tasks is handled
+# well, rather than attempting to properly handle tasks.
+
+mutable struct TaskTangent end
+
+tangent_type(::Type{Task}) = TaskTangent
+
+zero_tangent(p::Task) = TaskTangent()
+
+randn_tangent(rng::AbstractRNG, p::Task) = TaskTangent()
+
+increment!!(t::TaskTangent, s::TaskTangent) = t
+
+set_to_zero!!(t::TaskTangent) = t
+
+_add_to_primal(p::Task, t::TaskTangent) = p
+
+_diff(::Task, ::Task) = TaskTangent()
+
+_dot(::TaskTangent, ::TaskTangent) = 0.0
+
+_scale(::Float64, t::TaskTangent) = t
+
+TestUtils.populate_address_map!(m::TestUtils.AddressMap, ::Task, ::TaskTangent) = m
+
+# function zero_tangent(p::Task)
+#     return TaskTangent(
+#         zero_tangent(p.next),
+#         zero_tangent(p.queue),
+#         zero_tangent(p.storage),
+#         zero_tangent(p.donenotify),
+#         zero_tangent(p.result),
+#         zero_tangent(p.logstate),
+#         zero_tangent(p.code),
+#         ntuple(n -> NoTangent(), 9)...,
+#     )
+# end
+
+# function randn_tangent(rng::AbstractRNG, p::Task)
+#     return TaskTangent(
+#         randn_tangent(rng, p.next),
+#         randn_tangent(rng, p.queue),
+#         randn_tangent(rng, p.storage),
+#         randn_tangent(rng, p.donenotify),
+#         randn_tangent(rng, p.result),
+#         randn_tangent(rng, p.logstate),
+#         randn_tangent(rng, p.code),
+#         ntuple(n -> NoTangent(), 9)...,
+#     )
+# end
+
+# function increment!!(t::TaskTangent, s::TaskTangent)
+#     t === s && return t
+#     t.next = increment!!(t.next, s.next)
+#     t.queue = increment!!(t.queue, s.queue)
+#     t.storage = increment!!(t.storage, s.storage)
+#     t.donenotify = increment!!(t.donenotify, s.donenotify)
+#     t.result = increment!!(t.result, s.result)
+#     t.logstate = increment!!(t.logstate, s.logstate)
+#     t.code = increment!!(t.code, s.code)
+#     return t
+# end
+
+# function set_to_zero!!(t::TaskTangent)
+#     t.next = set_to_zero!!(t.next)
+#     t.queue = set_to_zero!!(t.queue)
+#     t.storage = set_to_zero!!(t.storage)
+#     t.donenotify = set_to_zero!!(t.donenotify)
+#     t.result = set_to_zero!!(t.result)
+#     t.logstate = set_to_zero!!(t.logstate)
+#     t.code = set_to_zero!!(t.code)
+#     return t
+# end
+
+# function _add_to_primal(p::Task, t::TaskTangent)
+#     p.next = _add_to_primal(p.next, t.next)
+#     p.queue = _add_to_primal(p.queue, t.queue)
+#     p.storage = _add_to_primal(p.storage, t.storage)
+#     p.donenotify = _add_to_primal(p.donenotify, t.donenotify)
+#     p.result = _add_to_primal(p.result, t.result)
+#     p.logstate = _add_to_primal(p.logstate, t.logstate)
+#     p.code = _add_to_primal(p.code, t.code)
+#     return p
+# end
+
+
+fdata_type(::Type{TaskTangent}) = TaskTangent
+
+rdata_type(::Type{TaskTangent}) = NoRData
+
+tangent(t::TaskTangent, ::NoRData) = t
+
+@inline function _get_fdata_field(_, t::TaskTangent, f...)
+    f === (:rngState0, ) && return NoFData()
+    f === (:rngState1, ) && return NoFData()
+    f === (:rngState2, ) && return NoFData()
+    f === (:rngState3, ) && return NoFData()
+    f === (:rngState4, ) && return NoFData()
+    throw(error("Unhandled field $f"))
+end
+
+@inline increment_field_rdata!(::TaskTangent, ::NoRData, ::Val) = nothing
+
+function get_tangent_field(t::TaskTangent, f)
+    f === :rngState0 && return NoTangent()
+    f === :rngState1 && return NoTangent()
+    f === :rngState2 && return NoTangent()
+    f === :rngState3 && return NoTangent()
+    f === :rngState4 && return NoTangent()
+    throw(error("Unhandled field $f"))
+end
+
+set_tangent_field!(t::TaskTangent, f, ::NoTangent) = NoTangent()
+
+@is_primitive MinimalCtx Tuple{typeof(current_task)}
+function rrule!!(f::CoDual{typeof(current_task)})
+    return zero_fcodual(current_task()), NoPullback(f)
+end
+
+_verify_fdata_value(::Task, ::TaskTangent) = nothing
+
+function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:tasks})
+    test_cases = Any[
+        (false, :none, nothing, lgetfield, Task(() -> nothing), Val(:rngState1)),
+        (false, :none, nothing, getfield, Task(() -> nothing), :rngState1),
+        (false, :none, nothing, lsetfield!, Task(() -> nothing), Val(:rngState1), UInt64(5)),
+        (false, :stability_and_allocs, nothing, current_task),
+    ]
+    memory = Any[]
+    return test_cases, memory
+end
+
+function generate_derived_rrule!!_test_cases(rng_ctor, ::Val{:tasks})
+    test_cases = Any[
+        (
+            false, :none, nothing,
+            (rng) -> (Random.seed!(rng, 0); rand(rng)), Random.default_rng(),
+        ),
+    ]
+    memory = Any[]
+    return test_cases, memory
+end

--- a/src/tangents.jl
+++ b/src/tangents.jl
@@ -70,7 +70,7 @@ const PossiblyMutableTangent{T} = Union{MutableTangent{T}, Tangent{T}}
 
 Gets the `i`th field of data in `t`.
 
-Has the same semantics that `setfield!` would have if the data in the `fields` field of `t`
+Has the same semantics that `getfield!` would have if the data in the `fields` field of `t`
 were actually fields of `t`. This is the moral equivalent of `getfield` for
 `MutableTangent`.
 """

--- a/test/rrules/tasks.jl
+++ b/test/rrules/tasks.jl
@@ -5,7 +5,6 @@
         y = zero_tangent(p)
         z = zero_tangent(p)
         TestUtils.test_tangent(sr(123456), p, x, y, z; interface_only=false, perf=false)
-        # TestUtils.test_fwds_rvs_data(sr(123456), p)
     end
     TestUtils.run_rrule!!_test_cases(StableRNG, Val(:tasks))
 end

--- a/test/rrules/tasks.jl
+++ b/test/rrules/tasks.jl
@@ -1,0 +1,11 @@
+@testset "tasks" begin
+    @testset "Task tangent functionality" begin
+        p = Task(() -> nothing)
+        x = zero_tangent(p)
+        y = zero_tangent(p)
+        z = zero_tangent(p)
+        TestUtils.test_tangent(sr(123456), p, x, y, z; interface_only=false, perf=false)
+        # TestUtils.test_fwds_rvs_data(sr(123456), p)
+    end
+    TestUtils.run_rrule!!_test_cases(StableRNG, Val(:tasks))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,6 +41,8 @@ include("front_matter.jl")
             include(joinpath("rrules", "misc.jl"))
             @info "new"
             include(joinpath("rrules", "new.jl"))
+            @info "tasks"
+            include(joinpath("rrules", "tasks.jl"))
         end
         include("chain_rules_macro.jl")
     elseif test_group == "integration_testing/misc"


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Tapir.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
This PR will resolve #182 . It adds _incredibly_ narrow support for getfield and setfield on tasks. You should not expect to actually be able to work properly with tasks as a consequence of this PR, just that they shouldn't get in the way when used as part of random number generation.