### PR TITLE
Improve safe mode messaging

### DIFF
--- a/ext/TapirLogDensityProblemsADExt.jl
+++ b/ext/TapirLogDensityProblemsADExt.jl
@@ -59,8 +59,9 @@ end
 # Interop with ADTypes.
 function ADgradient(x::ADTypes.AutoTapir, ℓ)
     if x.safe_mode
-        msg = "Running Tapir in safe mode. Disable for best performance. Do this by " *
-            "using AutoTapir(safe_mode=false)."
+        msg = "Running Tapir in safe mode. This mode is computationally expensive, " *
+            "should only be used when debugging a problem with AD, and turned off in " *
+            "general use. Do this by using AutoTapir(safe_mode=false)."
         @info msg
     end
     return ADgradient(Val(:Tapir), ℓ; safety_on=x.safe_mode)

--- a/src/safe_mode.jl
+++ b/src/safe_mode.jl
@@ -6,6 +6,8 @@ Construct a callable which is equivalent to `pb`, but which enforces type-based 
 post-conditions to `pb`. Let `dx = pb.pb(dy)`, for some rdata `dy`, then this function
 - checks that `dy` has the correct rdata type for `y`, and
 - checks that each element of `dx` has the correct rdata type for `x`.
+
+Reverse pass counterpart to [`SafeRRule`](@ref)
 """
 struct SafePullback{Tpb, Ty, Tx}
     pb::Tpb
@@ -64,6 +66,11 @@ the docstring for details.
 necessary but insufficient set of conditions to ensure correctness. If you find that an
 error isn't being caught by these tests, but you believe it ought to be, please open an
 issue or (better still) a PR.
+
+*Note:* this is a "safe mode" in the sense of operating systems. See e.g. this Wikipedia
+article: https://en.wikipedia.org/wiki/Safe_mode . Its purpose is to help with debugging,
+and should not be used when trying to differentiate code in general, as it decreases
+performance quite substantially in many cases.
 """
 struct SafeRRule{Trule}
     rule::Trule


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Tapir.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
Addresses #168 . As discussed in https://github.com/SciML/ADTypes.jl/pull/68, `safe_mode` is part of the public interface of `ADTypes` as it is a documented field of the `AutoTapir` type. This means that we cannot change it without making a breaking change to `ADTypes`. Since we can't do this, it seems preferable to simply clarify the nature of safe mode / the `safety_on` kwarg, then to rename it and have multiple names floating around.

The purpose of this PR, therefore, is to improve the documentation around safe_mode / safety_on, to ensure that users are aware of what it does.