### PR TITLE
Make JET a test-only dep

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,6 @@ DiffTests = "de460e47-3fe3-5279-bb4a-814414816d5d"
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
-JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MistyClosures = "dbe65cb8-6be2-42dd-bbc5-4196aaced4f4"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -22,11 +21,13 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 LogDensityProblemsAD = "996a588d-648d-4e1f-a8f0-a84b347e47b1"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 
 [extensions]
 TapirCUDAExt = "CUDA"
 TapirLogDensityProblemsADExt = "LogDensityProblemsAD"
 TapirSpecialFunctionsExt = "SpecialFunctions"
+TapirJETExt = "JET"
 
 [compat]
 ADTypes = "1.2"
@@ -60,6 +61,7 @@ Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 KernelFunctions = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 LogDensityProblemsAD = "996a588d-648d-4e1f-a8f0-a84b347e47b1"
 PDMats = "90014a1f-27ba-587c-ab20-58faa44d9150"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
@@ -70,4 +72,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 
 [targets]
-test = ["AbstractGPs", "BenchmarkTools", "CUDA", "DiffTests", "Distributions", "Documenter", "FillArrays", "KernelFunctions", "LogDensityProblemsAD", "PDMats", "ReverseDiff", "SpecialFunctions", "StableRNGs", "Test", "Turing", "TemporalGPs"]
+test = ["AbstractGPs", "BenchmarkTools", "CUDA", "DiffTests", "Distributions", "Documenter", "FillArrays", "KernelFunctions", "JET", "LogDensityProblemsAD", "PDMats", "ReverseDiff", "SpecialFunctions", "StableRNGs", "Test", "Turing", "TemporalGPs"]

--- a/ext/TapirJETExt.jl
+++ b/ext/TapirJETExt.jl
@@ -1,0 +1,7 @@
+module TapirJETExt
+
+    using JET, Tapir
+
+    Tapir.TestUtils.test_opt(::Tapir.TestUtils.Shim, args...) = JET.test_opt(args...)
+    Tapir.TestUtils.report_opt(::Tapir.TestUtils.Shim, tt) = JET.report_opt(tt)
+end

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -713,7 +713,8 @@ function test_set_tangent_field!_performance(t1::T, t2::T) where {V, T<:MutableT
 
         # Int mode.
         _set_tangent_field!(t1, Val(n), v)
-        JET.@report_opt _set_tangent_field!(t1, Val(n), v)
+        # JET.@report_opt _set_tangent_field!(t1, Val(n), v)
+        JET.report_opt(Tuple{typeof(_set_tangent_field!), typeof(t1), Val{n}, typeof(v)})
 
         if all(n -> !(fieldtype(V, n) <: Tapir.PossiblyUninitTangent), 1:fieldcount(V))
             i = Val(n)
@@ -724,7 +725,8 @@ function test_set_tangent_field!_performance(t1::T, t2::T) where {V, T<:MutableT
         # Symbol mode.
         s = Val(fieldname(V, n))
         @inferred _set_tangent_field!(t1, s, v)
-        JET.@report_opt _set_tangent_field!(t1, s, v)
+        # JET.@report_opt _set_tangent_field!(t1, s, v)
+        JET.report_opt(Tuple{typeof(set_tangent_field!), typeof(t1), typeof(s), typeof(v)})
 
         if all(n -> !(fieldtype(V, n) <: Tapir.PossiblyUninitTangent), 1:fieldcount(V))
             _set_tangent_field!(t1, s, v)
@@ -742,13 +744,15 @@ function test_get_tangent_field_performance(t::Union{MutableTangent, Tangent})
 
         # Int mode.
         i = Val(n)
-        JET.@report_opt _get_tangent_field(t, i)
+        JET.report_opt(Tuple{typeof(_get_tangent_field), typeof(t), typeof(i)})
+        # JET.@report_opt _get_tangent_field(t, i)
         @inferred _get_tangent_field(t, i)
         @test count_allocs(_get_tangent_field, t, i) == 0
 
         # Symbol mode.
         s = Val(fieldname(V, n))
-        JET.@report_opt _get_tangent_field(t, s)
+        JET.report_opt(Tuple{typeof(_get_tangent_field), typeof(t), typeof(s)})
+        # JET.@report_opt _get_tangent_field(t, s)
         @inferred _get_tangent_field(t, s)
         @test count_allocs(_get_tangent_field, t, s) == 0
     end

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -86,7 +86,7 @@ interfaces that this package defines have been implemented correctly.
 """
 module TestUtils
 
-using JET, Random, Tapir, Test, InteractiveUtils
+using Random, Tapir, Test, InteractiveUtils
 using Tapir:
     CoDual, NoTangent, rrule!!, is_init, zero_codual, DefaultCtx, @is_primitive, val,
     is_always_fully_initialised, get_tangent_field, set_tangent_field!, MutableTangent,
@@ -95,6 +95,16 @@ using Tapir:
     can_produce_zero_rdata_from_type, increment_rdata!!, fcodual_type,
     verify_fdata_type, verify_rdata_type, verify_fdata_value, verify_rdata_value,
     InvalidFDataException, InvalidRDataException
+
+struct Shim end
+
+function test_opt(::Any, args...)
+    throw(error("Load JET to use this function."))
+end
+
+function report_opt(::Any, tt)
+    throw(error("Load JET to use this function."))
+end
 
 has_equal_data(x::T, y::T; equal_undefs=true) where {T<:String} = x == y
 has_equal_data(x::Type, y::Type; equal_undefs=true) = x == y
@@ -384,15 +394,15 @@ function test_rrule_performance(
     if performance_checks_flag in (:stability, :stability_and_allocs)
 
         # Test primal stability.
-        JET.test_opt(primal(f_f̄), map(_typeof ∘ primal, x_x̄))
+        test_opt(Shim(), primal(f_f̄), map(_typeof ∘ primal, x_x̄))
 
         # Test forwards-pass stability.
-        JET.test_opt(rule, (_typeof(to_fwds(f_f̄)), map(_typeof ∘ to_fwds, x_x̄)...))
+        test_opt(Shim(), rule, (_typeof(to_fwds(f_f̄)), map(_typeof ∘ to_fwds, x_x̄)...))
 
         # Test reverse-pass stability.
         y_ȳ, pb!! = rule(to_fwds(f_f̄), map(to_fwds, _deepcopy(x_x̄))...)
         rvs_data = Tapir.rdata(zero_tangent(primal(y_ȳ), tangent(y_ȳ)))
-        JET.test_opt(pb!!, (_typeof(rvs_data), ))
+        test_opt(Shim(), pb!!, (_typeof(rvs_data), ))
     end
 
     if performance_checks_flag in (:allocs, :stability_and_allocs)
@@ -679,8 +689,8 @@ function test_tangent_performance(rng::AbstractRNG, p::P) where {P}
 
     # Check there are no allocations when there ought not to be.
     if !__tangent_generation_should_allocate(P)
-        JET.test_opt(Tuple{typeof(zero_tangent), P})
-        JET.test_opt(Tuple{typeof(randn_tangent), Xoshiro, P})
+        test_opt(Shim(), Tuple{typeof(zero_tangent), P})
+        test_opt(Shim(), Tuple{typeof(randn_tangent), Xoshiro, P})
     end
 
     # `increment!!` should always infer.
@@ -713,8 +723,10 @@ function test_set_tangent_field!_performance(t1::T, t2::T) where {V, T<:MutableT
 
         # Int mode.
         _set_tangent_field!(t1, Val(n), v)
-        # JET.@report_opt _set_tangent_field!(t1, Val(n), v)
-        JET.report_opt(Tuple{typeof(_set_tangent_field!), typeof(t1), Val{n}, typeof(v)})
+        report_opt(
+            Shim(),
+            Tuple{typeof(_set_tangent_field!), typeof(t1), Val{n}, typeof(v)},
+        )
 
         if all(n -> !(fieldtype(V, n) <: Tapir.PossiblyUninitTangent), 1:fieldcount(V))
             i = Val(n)
@@ -725,8 +737,10 @@ function test_set_tangent_field!_performance(t1::T, t2::T) where {V, T<:MutableT
         # Symbol mode.
         s = Val(fieldname(V, n))
         @inferred _set_tangent_field!(t1, s, v)
-        # JET.@report_opt _set_tangent_field!(t1, s, v)
-        JET.report_opt(Tuple{typeof(set_tangent_field!), typeof(t1), typeof(s), typeof(v)})
+        report_opt(
+            Shim(),
+            Tuple{typeof(_set_tangent_field!), typeof(t1), typeof(s), typeof(v)},
+        )
 
         if all(n -> !(fieldtype(V, n) <: Tapir.PossiblyUninitTangent), 1:fieldcount(V))
             _set_tangent_field!(t1, s, v)
@@ -744,15 +758,13 @@ function test_get_tangent_field_performance(t::Union{MutableTangent, Tangent})
 
         # Int mode.
         i = Val(n)
-        JET.report_opt(Tuple{typeof(_get_tangent_field), typeof(t), typeof(i)})
-        # JET.@report_opt _get_tangent_field(t, i)
+        report_opt(Shim(), Tuple{typeof(_get_tangent_field), typeof(t), typeof(i)})
         @inferred _get_tangent_field(t, i)
         @test count_allocs(_get_tangent_field, t, i) == 0
 
         # Symbol mode.
         s = Val(fieldname(V, n))
-        JET.report_opt(Tuple{typeof(_get_tangent_field), typeof(t), typeof(s)})
-        # JET.@report_opt _get_tangent_field(t, s)
+        report_opt(Shim(), Tuple{typeof(_get_tangent_field), typeof(t), typeof(s)})
         @inferred _get_tangent_field(t, s)
         @test count_allocs(_get_tangent_field, t, s) == 0
     end
@@ -898,13 +910,13 @@ function test_fwds_rvs_data(rng::AbstractRNG, p::P) where {P}
 
     # Check that when the zero element is asked from the primal type alone, the result is
     # either an instance of R _or_ a `CannotProduceZeroRDataFromType`.
-    JET.test_opt(zero_rdata_from_type, Tuple{Type{P}})
+    test_opt(Shim(), zero_rdata_from_type, Tuple{Type{P}})
     rzero_from_type = @inferred zero_rdata_from_type(P)
     @test rzero_from_type isa R || rzero_from_type isa CannotProduceZeroRDataFromType
     @test can_make_zero != isa(rzero_from_type, CannotProduceZeroRDataFromType)
 
     # Check that we can produce a lazy zero rdata, and that it has the correct type.
-    JET.test_opt(lazy_zero_rdata, Tuple{P})
+    test_opt(Shim(), lazy_zero_rdata, Tuple{P})
     lazy_rzero = @inferred lazy_zero_rdata(p)
     @test instantiate(lazy_rzero) isa R
 


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Tapir.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
Plan:
1. replace calls to `JET.report_opt` and `JET.test_opt` with calls to placeholder functions which always errors, and suggests loading JET
2. create extension for Tapir + JET which defines method of this placeholder function which actually does the right thing.