### PR TITLE
Attempt to get better errors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tapir"
 uuid = "07d77754-e150-4737-8c94-cd238a1fb45b"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.2.29"
+version = "0.2.30"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -1257,9 +1257,16 @@ mutable struct LazyDerivedRule{Tinterp<:TapirInterpreter, Trule}
     end
 end
 
-function (rule::LazyDerivedRule)(args::Vararg{Any, N}) where {N}
+function (rule::LazyDerivedRule{T, Trule})(args::Vararg{Any, N}) where {N, T, Trule}
     if !isdefined(rule, :rule)
-        rule.rule = build_rrule(rule.interp, rule.mi; safety_on=rule.safety_on)
+        rule = build_rrule(rule.interp, rule.mi; safety_on=rule.safety_on)
+        if rule isa Trule
+            rule.rule = rule
+        else
+            @warn "Unable to put rule in rule field. Rule should error."
+            rule(args...)
+            error("Rule with bad type ran without error.")
+        end
     end
     return rule.rule(args...)
 end

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -1264,7 +1264,7 @@ function (rule::LazyDerivedRule{T, Trule})(args::Vararg{Any, N}) where {N, T, Tr
             rule.rule = derived_rule
         else
             @warn "Unable to put rule in rule field. Rule should error."
-            @show typeof(rule)
+            @show typeof(derived_rule)
             @show Trule
             derived_rule(args...)
             error("Rule with bad type ran without error.")

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -827,7 +827,7 @@ function build_rrule(
         interp.oc_cache[(sig_or_mi, safety_on)] = (fwds_oc, pb_oc)
     end
 
-    raw_rule = rule_type(interp, sig_or_mi)(fwds_oc, pb_oc, Val(isva), Val(num_args(info)))
+    raw_rule = DerivedRule(fwds_oc, pb_oc, Val(isva), Val(num_args(info)))
     return safety_on ? SafeRRule(raw_rule) : raw_rule
 end
 
@@ -1259,12 +1259,14 @@ end
 
 function (rule::LazyDerivedRule{T, Trule})(args::Vararg{Any, N}) where {N, T, Trule}
     if !isdefined(rule, :rule)
-        rule = build_rrule(rule.interp, rule.mi; safety_on=rule.safety_on)
-        if rule isa Trule
-            rule.rule = rule
+        derived_rule = build_rrule(rule.interp, rule.mi; safety_on=rule.safety_on)
+        if derived_rule isa Trule
+            rule.rule = derived_rule
         else
             @warn "Unable to put rule in rule field. Rule should error."
-            rule(args...)
+            @show typeof(rule)
+            @show Trule
+            derived_rule(args...)
             error("Rule with bad type ran without error.")
         end
     end

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -720,21 +720,21 @@ function rule_type(interp::TapirInterpreter{C}, sig_or_mi) where {C}
     arg_rvs_types = Tuple{map(rdata_type ∘ tangent_type, arg_types)...}
     fwds_return_codual = fcodual_type(Treturn)
     rvs_return_type = rdata_type(tangent_type(Treturn))
-    if isconcretetype(fwds_return_codual)
+    # if isconcretetype(fwds_return_codual)
         return DerivedRule{
             MistyClosure{OpaqueClosure{arg_fwds_types, fwds_return_codual}},
             MistyClosure{OpaqueClosure{Tuple{rvs_return_type}, arg_rvs_types}},
             Val{isva},
             Val{length(ir.argtypes)},
         }
-    else
-        return DerivedRule{
-            MistyClosure{OpaqueClosure{arg_fwds_types, P}} where {P<:fwds_return_codual},
-            MistyClosure{OpaqueClosure{Tuple{rvs_return_type}, arg_rvs_types}},
-            Val{isva},
-            Val{length(ir.argtypes)},
-        }
-    end
+    # else
+    #     return DerivedRule{
+    #         MistyClosure{OpaqueClosure{arg_fwds_types, P}} where {P<:fwds_return_codual},
+    #         MistyClosure{OpaqueClosure{Tuple{rvs_return_type}, arg_rvs_types}},
+    #         Val{isva},
+    #         Val{length(ir.argtypes)},
+    #     }
+    # end
 end
 
 """

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -718,23 +718,13 @@ function rule_type(interp::TapirInterpreter{C}, sig_or_mi) where {C}
     arg_types = map(_type, ir.argtypes)
     arg_fwds_types = Tuple{map(fcodual_type, arg_types)...}
     arg_rvs_types = Tuple{map(rdata_type ∘ tangent_type, arg_types)...}
-    fwds_return_codual = fcodual_type(Treturn)
     rvs_return_type = rdata_type(tangent_type(Treturn))
-    # if isconcretetype(fwds_return_codual)
-        return DerivedRule{
-            MistyClosure{OpaqueClosure{arg_fwds_types, fwds_return_codual}},
-            MistyClosure{OpaqueClosure{Tuple{rvs_return_type}, arg_rvs_types}},
-            Val{isva},
-            Val{length(ir.argtypes)},
-        }
-    # else
-    #     return DerivedRule{
-    #         MistyClosure{OpaqueClosure{arg_fwds_types, P}} where {P<:fwds_return_codual},
-    #         MistyClosure{OpaqueClosure{Tuple{rvs_return_type}, arg_rvs_types}},
-    #         Val{isva},
-    #         Val{length(ir.argtypes)},
-    #     }
-    # end
+    return DerivedRule{
+        MistyClosure{OpaqueClosure{arg_fwds_types, fcodual_type(Treturn)}},
+        MistyClosure{OpaqueClosure{Tuple{rvs_return_type}, arg_rvs_types}},
+        Val{isva},
+        Val{length(ir.argtypes)},
+    }
 end
 
 """

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -1264,8 +1264,12 @@ function (rule::LazyDerivedRule{T, Trule})(args::Vararg{Any, N}) where {N, T, Tr
             rule.rule = derived_rule
         else
             @warn "Unable to put rule in rule field. Rule should error."
-            @show typeof(derived_rule)
-            @show Trule
+            println("derived_rule is of type")
+            display(typeof(derived_rule))
+            println()
+            println("Expected type is")
+            display(Trule)
+            println()
             derived_rule(args...)
             error("Rule with bad type ran without error.")
         end

--- a/src/rrules/blas.jl
+++ b/src/rrules/blas.jl
@@ -111,7 +111,7 @@ end
 # LEVEL 2
 #
 
-for (gemv, elty) in ((:dgemv_, :Float64), (:sgemm_, :Float32))
+for (gemv, elty) in ((:dgemv_, :Float64), (:sgemv_, :Float32))
     @eval @inline function rrule!!(
         ::CoDual{typeof(_foreigncall_)},
         ::CoDual{Val{$(blas_name(gemv))}},

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -4,7 +4,7 @@
 Central definition of typeof, which is specific to the use-required in this package.
 """
 _typeof(x) = Base._stable_typeof(x)
-_typeof(x::Tuple) = Tuple{map(_typeof, x)...}
+_typeof(x::Tuple) = Tuple{tuple_map(_typeof, x)...}
 _typeof(x::NamedTuple{names}) where {names} = NamedTuple{names, _typeof(Tuple(x))}
 
 """


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Tapir.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
At the minute, it is quite common for Tapir to error in a way that is quite uninformative if inference fails. This PR attempts to prevent this from happening by running the forwards-pass of AD if the return type isn't what we expect, rather than letting everything fall over without saying _why_.