### PR TITLE
symm rrule implementation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tapir"
 uuid = "07d77754-e150-4737-8c94-cd238a1fb45b"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.2.31"
+version = "0.2.32"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -1254,6 +1254,12 @@ function (rule::LazyDerivedRule{T, Trule})(args::Vararg{Any, N}) where {N, T, Tr
             rule.rule = derived_rule
         else
             @warn "Unable to put rule in rule field. Rule should error."
+            println("MethodInstance is")
+            display(rule.mi)
+            println()
+            println("with signature")
+            display(rule.mi.specTypes)
+            println()
             println("derived_rule is of type")
             display(typeof(derived_rule))
             println()

--- a/src/rrules/blas.jl
+++ b/src/rrules/blas.jl
@@ -111,7 +111,7 @@ end
 # LEVEL 2
 #
 
-for (gemv, elty) in ((:dgemv_, :Float64), (:sgemm_, :Float32))
+for (gemv, elty) in ((:dgemv_, :Float64), (:sgemv_, :Float32))
     @eval @inline function rrule!!(
         ::CoDual{typeof(_foreigncall_)},
         ::CoDual{Val{$(blas_name(gemv))}},

--- a/src/rrules/blas.jl
+++ b/src/rrules/blas.jl
@@ -455,7 +455,8 @@ function rrule!!(
         dβ = dot(dC, C)
 
         # gradient w.r.t. C.
-        dC .*= β
+        BLAS.scal!(β, dC)
+
         return NoRData(), NoRData(), NoRData(), dα, NoRData(), NoRData(), dβ, NoRData()
     end
     return C_dC, symm!_adjoint

--- a/src/rrules/blas.jl
+++ b/src/rrules/blas.jl
@@ -388,6 +388,78 @@ for (gemm, elty) in ((:dgemm_, :Float64), (:sgemm_, :Float32))
     end
 end
 
+@is_primitive(
+    MinimalCtx,
+    Tuple{
+        typeof(BLAS.symm!),
+        Char,
+        Char,
+        T,
+        MatrixOrView{T},
+        MatrixOrView{T},
+        T,
+        Matrix{T},
+    } where {T<:Union{Float32, Float64}},
+)
+
+function rrule!!(
+    ::CoDual{typeof(BLAS.symm!)},
+    side::CoDual{Char},
+    uplo::CoDual{Char},
+    alpha::CoDual{T},
+    A_dA::CoDual{<:MatrixOrView{T}},
+    B_dB::CoDual{<:MatrixOrView{T}},
+    beta::CoDual{T},
+    C_dC::CoDual{Matrix{T}},
+) where {T<:Union{Float32, Float64}}
+
+    # Extract primals.
+    s = primal(side)
+    ul = primal(uplo)
+    α = primal(alpha)
+    β = primal(beta)
+    A, dA = viewify(A_dA)
+    B, dB = viewify(B_dB)
+    C, dC = viewify(C_dC)
+
+    # Copy state and run symm!.
+    C_copy = copy(C)
+    BLAS.symm!(s, ul, α, A, B, β, C)
+
+    function symm!_adjoint(::NoRData)
+
+        # Reset C.
+        C .= C_copy
+
+        # gradient w.r.t. α. Safe to write into memory for copy of C.
+        BLAS.symm!(s, ul, one(T), A, B, zero(T), C_copy)
+        dα = dot(dC, C_copy)
+
+        # gradient w.r.t. A.
+        dA_tmp = s == 'L' ? dC * B' : B' * dC
+        if ul == 'L'
+            dA .+= α .* LowerTriangular(dA_tmp)
+            dA .+= α .* UpperTriangular(dA_tmp)'
+        else
+            dA .+= α .* LowerTriangular(dA_tmp)'
+            dA .+= α .* UpperTriangular(dA_tmp)
+        end
+        @inbounds for n in diagind(dA)
+            dA[n] -= α * dA_tmp[n]
+        end
+
+        # gradient w.r.t. B.
+        BLAS.symm!(s, ul, α, A, dC, one(T), dB)
+
+        # gradient w.r.t. beta.
+        dβ = dot(dC, C)
+
+        # gradient w.r.t. C.
+        dC .*= β
+        return NoRData(), NoRData(), NoRData(), dα, NoRData(), NoRData(), dβ, NoRData()
+    end
+    return C_dC, symm!_adjoint
+end
 
 for (syrk, elty) in ((:dsyrk_, :Float64), (:ssyrk_, :Float32))
     @eval function rrule!!(
@@ -625,6 +697,23 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:blas})
                     (false, :stability, nothing, BLAS.gemm!, tA, tB, a, A, B, b, C)
                 end
             end),
+        )),
+
+        # symm!
+        vec(reduce(
+            vcat,
+            vec(map(product(['L', 'R'], ['L', 'U'], alphas, betas)) do (side, uplo, α, β)
+                nA = side == 'L' ? 5 : 7
+                A = randn(nA, nA)
+                vA = view(randn(15, 15), 1:nA, 1:nA)
+                B = randn(5, 7)
+                vB = view(randn(15, 15), 1:5, 1:7)
+                C = randn(5, 7)
+                return Any[
+                    (false, :stability, nothing, BLAS.symm!, side, uplo, α, A, B, β, C),
+                    (false, :stability, nothing, BLAS.symm!, side, uplo, α, vA, vB, β, C),
+                ]
+            end)
         )),
     )
 


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Tapir.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
Adds a missing rule for `BLAS.symm!`. I believe that this is the last missing Level 3 BLAS rule that we were missing!