### PR TITLE
fptrunc and more debugging info

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tapir"
 uuid = "07d77754-e150-4737-8c94-cd238a1fb45b"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.2.32"
+version = "0.2.33"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -1236,18 +1236,18 @@ If `safety_on` is `true`, then the rule constructed will be a `SafeRRule`. This 
 when debugging, but should usually be switched off for production code as it (in general)
 incurs some runtime overhead.
 =#
-mutable struct LazyDerivedRule{Tinterp<:TapirInterpreter, Trule}
+mutable struct LazyDerivedRule{Tinterp<:TapirInterpreter, Tspec_types, Trule}
     interp::Tinterp
     safety_on::Bool
     mi::Core.MethodInstance
     rule::Trule
     function LazyDerivedRule(interp::A, mi::Core.MethodInstance, safety_on::Bool) where {A}
         rt = rule_type(interp, mi)
-        return new{A, safety_on ? SafeRRule{rt} : rt}(interp, safety_on, mi)
+        return new{A, mi.specTypes, safety_on ? SafeRRule{rt} : rt}(interp, safety_on, mi)
     end
 end
 
-function (rule::LazyDerivedRule{T, Trule})(args::Vararg{Any, N}) where {N, T, Trule}
+function (rule::LazyDerivedRule{T, sig, Trule})(args::Vararg{Any, N}) where {N, T, sig, Trule}
     if !isdefined(rule, :rule)
         derived_rule = build_rrule(rule.interp, rule.mi; safety_on=rule.safety_on)
         if derived_rule isa Trule
@@ -1258,7 +1258,7 @@ function (rule::LazyDerivedRule{T, Trule})(args::Vararg{Any, N}) where {N, T, Tr
             display(rule.mi)
             println()
             println("with signature")
-            display(rule.mi.specTypes)
+            display(sig)
             println()
             println("derived_rule is of type")
             display(typeof(derived_rule))

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -1235,8 +1235,13 @@ does not have to be derived.
 If `safety_on` is `true`, then the rule constructed will be a `SafeRRule`. This is useful
 when debugging, but should usually be switched off for production code as it (in general)
 incurs some runtime overhead.
+
+Note: the signature of the primal for which this is a rule is stored in the type. The only
+reason to keep this around is for debugging -- it is very helpful to have this type visible
+in the stack trace when something goes wrong, as it allows you to trivially determine which
+bit of your code is the culprit.
 =#
-mutable struct LazyDerivedRule{Tinterp<:TapirInterpreter, Tspec_types, Trule}
+mutable struct LazyDerivedRule{Tinterp<:TapirInterpreter, primal_sig, Trule}
     interp::Tinterp
     safety_on::Bool
     mi::Core.MethodInstance

--- a/src/rrules/builtins.jl
+++ b/src/rrules/builtins.jl
@@ -247,7 +247,13 @@ end
 @inactive_intrinsic fptosi
 @inactive_intrinsic fptoui
 
-# fptrunc -- maybe interesting
+@intrinsic fptrunc
+function rrule!!(
+    ::CoDual{typeof(fptrunc)}, ::CoDual{Type{Ptrunc}}, x::CoDual{P}
+) where {Ptrunc<:IEEEFloat, P<:IEEEFloat}
+    fptrunc_adjoint!!(dy) = NoRData(), NoRData(), convert(P, dy)
+    return zero_fcodual(fptrunc(Ptrunc, primal(x))), fptrunc_adjoint!!
+end
 
 @inactive_intrinsic have_fma
 @inactive_intrinsic le_float
@@ -821,7 +827,7 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:builtins})
         (false, :stability, nothing, IntrinsicsWrappers.fpiseq, 4.1, 4.0),
         (false, :stability, nothing, IntrinsicsWrappers.fptosi, UInt32, 4.1),
         (false, :stability, nothing, IntrinsicsWrappers.fptoui, Int32, 4.1),
-        # fptrunc -- maybe interesting
+        (true, :stability, nothing, IntrinsicsWrappers.fptrunc, Float32, 5.0),
         (true, :stability, nothing, IntrinsicsWrappers.have_fma, Float64),
         (false, :stability, nothing, IntrinsicsWrappers.le_float, 4.1, 4.0),
         (false, :stability, nothing, IntrinsicsWrappers.le_float_fast, 4.1, 4.0),


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Tapir.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
- Adds rule for `Core.Intrinsics.fptrunc`.
- Includes the signature in `LazyDerivedRule` again -- this is a very useful thing to have in the stack trace when trying to isolate problems.
