### PR TITLE
GC Preservation and Thread Safety

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tapir"
 uuid = "07d77754-e150-4737-8c94-cd238a1fb45b"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.2.38"
+version = "0.2.39"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Tapir.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
This PR just adds `GC.@preserve` statements in bunch of places, and ensures that only one thread is doing inference at a time -- this seems to resolve any thread safety issues on my end. Annoyingly, it's not at all clear to me how best to write unit tests for this behaviour, so it's not tested.