### PR TITLE
Disable More Unsafe GlobalRef Uses

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tapir"
 uuid = "07d77754-e150-4737-8c94-cd238a1fb45b"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.2.40"
+version = "0.2.41"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tapir"
 uuid = "07d77754-e150-4737-8c94-cd238a1fb45b"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.2.41"
+version = "0.2.40"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -417,7 +417,7 @@ end
 # and the ID associated to it in the forwards- and reverse-passes returned.
 function const_codual(stmt, info::ADInfo)
     x = uninit_fcodual(get_const_primal_value(stmt))
-    return isbitstype(_typeof(x)) ? x : add_data!(info, x)
+    return (isbits(x) || x isa CoDual{<:Type}) ? x : add_data!(info, x)
 end
 
 # Get the value associated to `x`. For `GlobalRef`s, verify that `x` is indeed a constant.

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -400,12 +400,6 @@ function make_ad_stmts!(stmt::GlobalRef, line::ID, info::ADInfo)
     )
 end
 
-# Helper used by `make_ad_stmts! ` for `GlobalRef`. Noinline to avoid IR bloat.
-@noinline function __verify_const(global_ref, stored_value)
-    @assert global_ref == primal(stored_value)
-    return uninit_fcodual(global_ref)
-end
-
 # QuoteNodes are constant.
 make_ad_stmts!(stmt::QuoteNode, line::ID, info::ADInfo) = const_ad_stmt(stmt, line, info)
 

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -400,6 +400,12 @@ function make_ad_stmts!(stmt::GlobalRef, line::ID, info::ADInfo)
     )
 end
 
+# Helper used by `make_ad_stmts! ` for `GlobalRef`. Noinline to avoid IR bloat.
+@noinline function __verify_const(global_ref, stored_value)
+    @assert global_ref == primal(stored_value)
+    return uninit_fcodual(global_ref)
+end
+
 # QuoteNodes are constant.
 make_ad_stmts!(stmt::QuoteNode, line::ID, info::ADInfo) = const_ad_stmt(stmt, line, info)
 

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -384,7 +384,8 @@ end
 # run-time that the value has not changed.
 function make_ad_stmts!(stmt::GlobalRef, line::ID, info::ADInfo)
 
-    # Constant isbits globals are safe to work with.
+    # Constant isbits globals are safe to work with. Types are a special case, in that they
+    # aren't bits types, but certainly don't ever get modified.
     x = getglobal(stmt.mod, stmt.name)
     if isconst(stmt) && (isbits(x) || x isa Type)
         return const_ad_stmt(stmt, line, info)

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -384,8 +384,7 @@ end
 # run-time that the value has not changed.
 function make_ad_stmts!(stmt::GlobalRef, line::ID, info::ADInfo)
 
-    # Constant isbits globals are safe to work with. Types are a special case, in that they
-    # aren't bits types, but certainly don't ever get modified.
+    # Constant isbits globals are safe to work with.
     x = getglobal(stmt.mod, stmt.name)
     if isconst(stmt) && (isbits(x) || x isa Type)
         return const_ad_stmt(stmt, line, info)

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -417,7 +417,7 @@ end
 # and the ID associated to it in the forwards- and reverse-passes returned.
 function const_codual(stmt, info::ADInfo)
     x = uninit_fcodual(get_const_primal_value(stmt))
-    return (isbits(x) || x isa CoDual{<:Type}) ? x : add_data!(info, x)
+    return isbitstype(_typeof(x)) ? x : add_data!(info, x)
 end
 
 # Get the value associated to `x`. For `GlobalRef`s, verify that `x` is indeed a constant.

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -383,15 +383,20 @@ end
 # assuming that they are constant, and creating a CoDual with the value. We then check at
 # run-time that the value has not changed.
 function make_ad_stmts!(stmt::GlobalRef, line::ID, info::ADInfo)
-    isconst(stmt) && return const_ad_stmt(stmt, line, info)
 
-    x = const_codual(getglobal(stmt.mod, stmt.name), info)
-    globalref_id = ID()
-    fwds = [
-        (globalref_id, new_inst(stmt)),
-        (line, new_inst(Expr(:call, __verify_const, globalref_id, x))),
-    ]
-    return ad_stmt_info(line, fwds, nothing)
+    # Constant isbits globals are safe to work with.
+    x = getglobal(stmt.mod, stmt.name)
+    if isconst(stmt) && (isbits(x) || x isa Type)
+        return const_ad_stmt(stmt, line, info)
+    end
+
+    # Anything else can potentially be mutated, and is therefore unsafe.
+    unhandled_feature(
+        "Global variable $stmt is either not isbits, or not declared to be a constant. " *
+        "Such globals are not supported. " *
+        "Please refactor your code to avoid assigning to a global, for example by " *
+        "passing the variable in to the function as an argument."
+    )
 end
 
 # Helper used by `make_ad_stmts! ` for `GlobalRef`. Noinline to avoid IR bloat.

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -588,6 +588,13 @@ function make_ad_stmts!(stmt::Expr, line::ID, info::ADInfo)
     ]
         # Expressions which do not require any special treatment.
         return ad_stmt_info(line, stmt, nothing)
+
+    elseif stmt.head == :(=) && stmt.args[1] isa GlobalRef
+        msg = "Encountered assignment to global variable: $(stmt.args[1]). " *
+            "Cannot differentiate through assignments to globals. " *
+            "Please refactor your code to avoid assigning to a global, for example by " *
+            "passing the variable in to the function as an argument."
+        throw(UnhandledLanguageFeatureException(msg))
     else
         # Encountered an expression that we've not seen before.
         throw(error("Unrecognised expression $stmt"))

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -594,7 +594,7 @@ function make_ad_stmts!(stmt::Expr, line::ID, info::ADInfo)
             "Cannot differentiate through assignments to globals. " *
             "Please refactor your code to avoid assigning to a global, for example by " *
             "passing the variable in to the function as an argument."
-        throw(UnhandledLanguageFeatureException(msg))
+        unhandled_feature(msg)
     else
         # Encountered an expression that we've not seen before.
         throw(error("Unrecognised expression $stmt"))

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1482,13 +1482,6 @@ function inlinable_vararg_invoke_call(
     return invoke(vararg_test_for_invoke, Tuple{typeof(rows), Vararg{N}}, rows, n1, ns...)
 end
 
-# build_rrule should error for this function, because it references a non-isbits global ref.
-const __x_for_mutable_global_ref = Ref(1.0)
-function mutable_global_ref(y::Float64)
-    __x_for_mutable_global_ref[] = y
-    return __x_for_mutable_global_ref[]
-end
-
 # build_rrule should error for this function, because it references a non-const global ref.
 __x_for_non_const_global_ref::Float64 = 5.0
 function non_const_global_ref(y::Float64)

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1482,6 +1482,13 @@ function inlinable_vararg_invoke_call(
     return invoke(vararg_test_for_invoke, Tuple{typeof(rows), Vararg{N}}, rows, n1, ns...)
 end
 
+# build_rrule should error for this function, because it references a non-isbits global ref.
+const __x_for_mutable_global_ref = Ref(1.0)
+function mutable_global_ref(y::Float64)
+    __x_for_mutable_global_ref[] = y
+    return __x_for_mutable_global_ref[]
+end
+
 # build_rrule should error for this function, because it references a non-const global ref.
 __x_for_non_const_global_ref::Float64 = 5.0
 function non_const_global_ref(y::Float64)

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1482,6 +1482,20 @@ function inlinable_vararg_invoke_call(
     return invoke(vararg_test_for_invoke, Tuple{typeof(rows), Vararg{N}}, rows, n1, ns...)
 end
 
+# build_rrule should error for this function, because it references a non-isbits global ref.
+const __x_for_mutable_global_ref = Ref(1.0)
+function mutable_global_ref(y::Float64)
+    __x_for_mutable_global_ref[] = y
+    return __x_for_mutable_global_ref[]
+end
+
+# build_rrule should error for this function, because it references a non-const global ref.
+__x_for_non_const_global_ref::Float64 = 5.0
+function non_const_global_ref(y::Float64)
+    global __x_for_non_const_global_ref = y
+    return __x_for_non_const_global_ref
+end
+
 function generate_test_functions()
     return Any[
         (false, :allocs, nothing, const_tester),

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1155,6 +1155,9 @@ const __x_for_gref_tester_3 = 5.0
 const __x_for_gref_tester_4::Float64 = 3.0
 @eval globalref_tester_4() = $(GlobalRef(@__MODULE__, :__x_for_gref_tester_4))
 
+__x_for_gref_tester_5 = 5.0
+@eval globalref_tester_5() = $(GlobalRef(@__MODULE__, :__x_for_gref_tester_5))
+
 type_unstable_tester_0(x::Ref{Any}) = x[]
 
 type_unstable_tester(x::Ref{Any}) = cos(x[])
@@ -1524,6 +1527,7 @@ function generate_test_functions()
         (false, :none, nothing, globalref_tester_2, false),
         (false, :allocs, nothing, globalref_tester_3),
         (false, :allocs, nothing, globalref_tester_4),
+        (false, :none, nothing, globalref_tester_5),
         (false, :none, (lb=1, ub=1_000), type_unstable_tester_0, Ref{Any}(5.0)),
         (false, :none, nothing, type_unstable_tester, Ref{Any}(5.0)),
         (false, :none, nothing, type_unstable_tester_2, Ref{Real}(5.0)),

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1155,9 +1155,6 @@ const __x_for_gref_tester_3 = 5.0
 const __x_for_gref_tester_4::Float64 = 3.0
 @eval globalref_tester_4() = $(GlobalRef(@__MODULE__, :__x_for_gref_tester_4))
 
-__x_for_gref_tester_5 = 5.0
-@eval globalref_tester_5() = $(GlobalRef(@__MODULE__, :__x_for_gref_tester_5))
-
 type_unstable_tester_0(x::Ref{Any}) = x[]
 
 type_unstable_tester(x::Ref{Any}) = cos(x[])
@@ -1527,7 +1524,6 @@ function generate_test_functions()
         (false, :none, nothing, globalref_tester_2, false),
         (false, :allocs, nothing, globalref_tester_3),
         (false, :allocs, nothing, globalref_tester_4),
-        (false, :none, nothing, globalref_tester_5),
         (false, :none, (lb=1, ub=1_000), type_unstable_tester_0, Ref{Any}(5.0)),
         (false, :none, nothing, type_unstable_tester, Ref{Any}(5.0)),
         (false, :none, nothing, type_unstable_tester_2, Ref{Real}(5.0)),

--- a/test/interpreter/s2s_reverse_mode_ad.jl
+++ b/test/interpreter/s2s_reverse_mode_ad.jl
@@ -254,13 +254,6 @@ end
             Tapir.UnhandledLanguageFeatureException,
             Tapir.build_rrule(
                 Tapir.TapirInterpreter(),
-                Tuple{typeof(Tapir.TestResources.mutable_global_ref), Float64},
-            ),
-        )
-        @test_throws(
-            Tapir.UnhandledLanguageFeatureException,
-            Tapir.build_rrule(
-                Tapir.TapirInterpreter(),
                 Tuple{typeof(Tapir.TestResources.non_const_global_ref), Float64},
             )
         )

--- a/test/interpreter/s2s_reverse_mode_ad.jl
+++ b/test/interpreter/s2s_reverse_mode_ad.jl
@@ -249,6 +249,23 @@ end
         # @profview(run_many_times(500, f, rule, fwds_args, out))
     end
 
+    @testset "integration testing for invalid global ref errors" begin
+        @test_throws(
+            Tapir.UnhandledLanguageFeatureException,
+            Tapir.build_rrule(
+                Tapir.TapirInterpreter(),
+                Tuple{typeof(Tapir.TestResources.mutable_global_ref), Float64},
+            ),
+        )
+        @test_throws(
+            Tapir.UnhandledLanguageFeatureException,
+            Tapir.build_rrule(
+                Tapir.TapirInterpreter(),
+                Tuple{typeof(Tapir.TestResources.non_const_global_ref), Float64},
+            )
+        )
+    end
+
     # Tests designed to prevent accidentally re-introducing issues which we have fixed.
     @testset "regression tests" begin
 

--- a/test/interpreter/s2s_reverse_mode_ad.jl
+++ b/test/interpreter/s2s_reverse_mode_ad.jl
@@ -143,6 +143,7 @@ end
             @testset "non-const" begin
                 global_ref = GlobalRef(S2SGlobals, :non_const_global)
                 stmt_info = make_ad_stmts!(global_ref, ID(), info)
+                @test Tapir.TestResources.non_const_global_ref(5.0) == 5.0 # run primal
                 @test stmt_info isa Tapir.ADStmtInfo
                 @test Meta.isexpr(last(stmt_info.fwds)[2].stmt, :call)
                 @test last(stmt_info.fwds)[2].stmt.args[1] == Tapir.__verify_const

--- a/test/interpreter/s2s_reverse_mode_ad.jl
+++ b/test/interpreter/s2s_reverse_mode_ad.jl
@@ -254,6 +254,13 @@ end
             Tapir.UnhandledLanguageFeatureException,
             Tapir.build_rrule(
                 Tapir.TapirInterpreter(),
+                Tuple{typeof(Tapir.TestResources.mutable_global_ref), Float64},
+            ),
+        )
+        @test_throws(
+            Tapir.UnhandledLanguageFeatureException,
+            Tapir.build_rrule(
+                Tapir.TapirInterpreter(),
                 Tuple{typeof(Tapir.TestResources.non_const_global_ref), Float64},
             )
         )

--- a/test/interpreter/s2s_reverse_mode_ad.jl
+++ b/test/interpreter/s2s_reverse_mode_ad.jl
@@ -140,15 +140,17 @@ end
             end
         end
         @testset "GlobalRef" begin
+            @testset "non-const" begin
+                global_ref = GlobalRef(S2SGlobals, :non_const_global)
+                stmt_info = make_ad_stmts!(global_ref, ID(), info)
+                @test stmt_info isa Tapir.ADStmtInfo
+                @test Meta.isexpr(last(stmt_info.fwds)[2].stmt, :call)
+                @test last(stmt_info.fwds)[2].stmt.args[1] == Tapir.__verify_const
+            end
             @testset "differentiable const globals" begin
                 stmt_info = make_ad_stmts!(GlobalRef(S2SGlobals, :const_float), ID(), info)
                 @test stmt_info isa Tapir.ADStmtInfo
                 @test only(stmt_info.fwds)[2].stmt isa CoDual{Float64}
-            end
-            @testset "GlobalRefs should definitely work for types" begin
-                stmt_info = make_ad_stmts!(GlobalRef(Base, :IteratorEltype), ID(), info)
-                @test stmt_info isa Tapir.ADStmtInfo
-                @test only(stmt_info.fwds)[2].stmt isa CoDual{<:Type}
             end
         end
         @testset "PhiCNode" begin

--- a/test/interpreter/s2s_reverse_mode_ad.jl
+++ b/test/interpreter/s2s_reverse_mode_ad.jl
@@ -140,17 +140,15 @@ end
             end
         end
         @testset "GlobalRef" begin
-            @testset "non-const" begin
-                global_ref = GlobalRef(S2SGlobals, :non_const_global)
-                stmt_info = make_ad_stmts!(global_ref, ID(), info)
-                @test stmt_info isa Tapir.ADStmtInfo
-                @test Meta.isexpr(last(stmt_info.fwds)[2].stmt, :call)
-                @test last(stmt_info.fwds)[2].stmt.args[1] == Tapir.__verify_const
-            end
             @testset "differentiable const globals" begin
                 stmt_info = make_ad_stmts!(GlobalRef(S2SGlobals, :const_float), ID(), info)
                 @test stmt_info isa Tapir.ADStmtInfo
                 @test only(stmt_info.fwds)[2].stmt isa CoDual{Float64}
+            end
+            @testset "GlobalRefs should definitely work for types" begin
+                stmt_info = make_ad_stmts!(GlobalRef(Base, :IteratorEltype), ID(), info)
+                @test stmt_info isa Tapir.ADStmtInfo
+                @test only(stmt_info.fwds)[2].stmt isa CoDual{<:Type}
             end
         end
         @testset "PhiCNode" begin

--- a/test/interpreter/s2s_reverse_mode_ad.jl
+++ b/test/interpreter/s2s_reverse_mode_ad.jl
@@ -166,6 +166,12 @@ end
             )
         end
         @testset "Expr" begin
+            @testset "assignment to GlobalRef" begin
+                @test_throws(
+                    Tapir.UnhandledLanguageFeatureException,
+                    make_ad_stmts!(Expr(:(=), GlobalRef(Main, :a), 5.0), ID(), info)
+                )
+            end
             @testset "copyast" begin
                 stmt = Expr(:copyast, QuoteNode(:(hi)))
                 ad_stmts = make_ad_stmts!(stmt, ID(), info)


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Tapir.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
We say in a couple of places that non-constant `GlobalRef`s, or constant `GlobalRef`s containing mutable data, cannot be used. Unfortunately, this hasn't actually been enforced anywhere. This PR enforces it more carefully, and provides reasonable error messages that explain what has happened when someone attempts to do this.

edit: sadly, it's not possible yet to properly prevent all of the things that could go wrong. I'm going to add a note to the docs explaining what you ought not to do with globals.