### PR TITLE
NoPullback for hash

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tapir"
 uuid = "07d77754-e150-4737-8c94-cd238a1fb45b"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.2.43"
+version = "0.2.44"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/codual.jl
+++ b/src/codual.jl
@@ -15,7 +15,7 @@ end
 primal(x::CoDual) = x.x
 tangent(x::CoDual) = x.dx
 Base.copy(x::CoDual) = CoDual(copy(primal(x)), copy(tangent(x)))
-_copy(x::P) where {P<:CoDual} = P(_copy(x.x), _copy(x.dx))
+_copy(x::P) where {P<:CoDual} = x
 
 """
     zero_codual(x)

--- a/src/fwds_rvs_data.jl
+++ b/src/fwds_rvs_data.jl
@@ -200,8 +200,10 @@ fdata_type(::Type{T}) where {T<:Ptr} = T
     isa(P, Union) && return Union{fdata_type(P.a), fdata_type(P.b)}
     isempty(P.parameters) && return NoFData
     isa(last(P.parameters), Core.TypeofVararg) && return Any
-    all(p -> fdata_type(p) == NoFData, P.parameters) && return NoFData
-    return Tuple{map(fdata_type, fieldtypes(P))...}
+    nofdata_tt = Tuple{Vararg{NoFData, length(P.parameters)}}
+    fdata_tt = Tuple{map(fdata_type, fieldtypes(P))...}
+    fdata_tt <: nofdata_tt && return NoFData
+    return nofdata_tt <: fdata_tt ? Union{NoFData, fdata_tt} : fdata_tt
 end
 
 @generated function fdata_type(::Type{NamedTuple{names, T}}) where {names, T<:Tuple}
@@ -444,10 +446,10 @@ rdata_type(::Type{<:Ptr}) = NoRData
     isa(P, Union) && return Union{rdata_type(P.a), rdata_type(P.b)}
     isempty(P.parameters) && return NoRData
     isa(last(P.parameters), Core.TypeofVararg) && return Any
-    nordata_tuple = Tuple{Vararg{NoRData, length(P.parameters)}}
-    rdata_type_tuple = Tuple{map(rdata_type, fieldtypes(P))...}
-    rdata_type_tuple <: nordata_tuple && return NoRData
-    return nordata_tuple <: rdata_type_tuple ? Union{NoRData, rdata_type_tuple} : rdata_type_tuple
+    nordata_tt = Tuple{Vararg{NoRData, length(P.parameters)}}
+    rdata_tt = Tuple{map(rdata_type, fieldtypes(P))...}
+    rdata_tt <: nordata_tt && return NoRData
+    return nordata_tt <: rdata_tt ? Union{NoRData, rdata_tt} : rdata_tt
 end
 
 function rdata_type(::Type{NamedTuple{names, T}}) where {names, T<:Tuple}

--- a/src/fwds_rvs_data.jl
+++ b/src/fwds_rvs_data.jl
@@ -444,8 +444,10 @@ rdata_type(::Type{<:Ptr}) = NoRData
     isa(P, Union) && return Union{rdata_type(P.a), rdata_type(P.b)}
     isempty(P.parameters) && return NoRData
     isa(last(P.parameters), Core.TypeofVararg) && return Any
-    all(p -> rdata_type(p) == NoRData, P.parameters) && return NoRData
-    return Tuple{map(rdata_type, fieldtypes(P))...}
+    nordata_tuple = Tuple{Vararg{NoRData, length(P.parameters)}}
+    rdata_type_tuple = Tuple{map(rdata_type, fieldtypes(P))...}
+    rdata_type_tuple <: nordata_tuple && return NoRData
+    return nordata_tuple <: rdata_type_tuple ? Union{NoRData, rdata_type_tuple} : rdata_type_tuple
 end
 
 function rdata_type(::Type{NamedTuple{names, T}}) where {names, T<:Tuple}

--- a/src/rrules/foreigncall.jl
+++ b/src/rrules/foreigncall.jl
@@ -613,6 +613,8 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:foreigncall})
         (false, :stability, nothing, deepcopy, (a=5.0, b=randn(5))),
         (false, :none, nothing, UnionAll, TypeVar(:a), Real),
         (false, :none, nothing, hash, "5", UInt(3)),
+        (false, :none, nothing, hash, Float64, UInt(5)),
+        (false, :none, nothing, hash, Float64),
         (
             true, :none, nothing,
             _foreigncall_,

--- a/src/rrules/foreigncall.jl
+++ b/src/rrules/foreigncall.jl
@@ -489,12 +489,11 @@ function rrule!!(f::CoDual{<:Type{UnionAll}}, x::CoDual{<:TypeVar}, y::CoDual{<:
     return zero_fcodual(UnionAll(primal(x), primal(y))), NoPullback(f, x, y)
 end
 
-@is_primitive MinimalCtx Tuple{typeof(hash), Union{String, SubString{String}}, UInt}
-function rrule!!(
-    f::CoDual{typeof(hash)}, s::CoDual{P}, h::CoDual{UInt}
-) where {P<:Union{String, SubString{String}}}
-    return zero_fcodual(hash(primal(s), primal(h))), NoPullback(f, s, h)
+@is_primitive MinimalCtx Tuple{typeof(hash), Vararg}
+function rrule!!(f::CoDual{typeof(hash)}, x::Vararg{CoDual, N}) where {N}
+    return zero_fcodual(hash(map(primal, x)...)), NoPullback(f, x...)
 end
+
 
 function rrule!!(
     ::CoDual{typeof(_foreigncall_)}, ::CoDual{Val{:jl_string_ptr}}, args::Vararg{CoDual, N}

--- a/test/fwds_rvs_data.jl
+++ b/test/fwds_rvs_data.jl
@@ -3,9 +3,19 @@ module FwdsRvsDataTestResources
 end
 
 @testset "fwds_rvs_data" begin
-    @testset "rdata_type($P)" for (P, R) in Any[
-        (Tuple{Any, Vector{Float64}}, Union{NoRData, Tuple{Any, NoRData}}),
+    @testset "fdata_type / rdata_type($P)" for (P, F, R) in Any[
+        (
+            Tuple{Any, Vector{Float64}},
+            Tuple{Any, Vector{Float64}},
+            Union{NoRData, Tuple{Any, NoRData}},
+        ),
+        (
+            Tuple{Any, Float64},
+            Union{NoFData, Tuple{Any, NoFData}},
+            Tuple{Any, Float64},
+        ),
     ]
+        @test fdata_type(tangent_type(P)) == F
         @test rdata_type(tangent_type(P)) == R
     end
     @testset "$(typeof(p))" for (_, p, _...) in Tapir.tangent_test_cases()

--- a/test/fwds_rvs_data.jl
+++ b/test/fwds_rvs_data.jl
@@ -3,6 +3,11 @@ module FwdsRvsDataTestResources
 end
 
 @testset "fwds_rvs_data" begin
+    @testset "rdata_type($P)" for (P, R) in Any[
+        (Tuple{Any, Vector{Float64}}, Union{NoRData, Tuple{Any, NoRData}}),
+    ]
+        @test rdata_type(tangent_type(P)) == R
+    end
     @testset "$(typeof(p))" for (_, p, _...) in Tapir.tangent_test_cases()
         TestUtils.test_fwds_rvs_data(Xoshiro(123456), p)
     end


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Tapir.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
Previously, the `rrule!!` for `hash` was rather conservative in the cases that it attempted to cover. Any reasonable implementation of `hash` is going not going to be differentiable, since it returns an integer, so I've just made it so that _all_ methods of `hash` have `NoPullback` returned.

This is necessary in some cases to avoid ccalls, but will be a good performance optimisation in many cases.