### PR TITLE
Speed up benchmarking

### DIFF
--- a/bench/Project.toml
+++ b/bench/Project.toml
@@ -1,7 +1,7 @@
 [deps]
 AbstractGPs = "99985d1d-32ba-4be9-9821-2ec096f28918"
-BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+Chairmarks = "0ca39b1e-fe0b-4e98-acfc-b1656634c4de"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 KernelFunctions = "ec8451be-7e33-11e9-00cf-bbf324bd1392"

--- a/src/rrules/low_level_maths.jl
+++ b/src/rrules/low_level_maths.jl
@@ -79,8 +79,8 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:low_level_mat
         (f == :rem2pi || f == :ldexp || f == :(^)) && return
         (f == :+ || f == :*) && return # use intrinsics instead
         f = @eval $M.$f
-        push!(test_cases, Any[false, :stability, nothing, f, rand_inputs(rng, Float64, f, arity)...])
-        push!(test_cases, Any[true, :stability, nothing, f, rand_inputs(rng, Float32, f, arity)...])
+        push!(test_cases, (false, :stability, nothing, f, rand_inputs(rng, Float64, f, arity)...))
+        push!(test_cases, (true, :stability, nothing, f, rand_inputs(rng, Float32, f, arity)...))
     end
     memory = Any[]
     return test_cases, memory


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Tapir.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
Benchmarking is currently the most time-consuming aspect of CI. This is a problem, because it slows down how quickly we can get quick fixes merged during the course of the working day. This is mainly a problem for small quick fixes, which perhaps take a couple of minutes to sort out, but require waiting roughly an hour for CI to run. The overall effect is to make the development cycle less snappy -- ideally we'd be able to get things merged much more quickly.

Fortunately, most time spent benchmarking is associated to BenchmarkTools.jl tuning benchmarks. Chairmarks.jl takes a different approach to tuning which winds up being quite a lot quicker. In this PR I explore what swapping out BenchmarkTools for Chairmarks does to the time it takes for the benchmarking CI to pass. Local tests indicate that it remains stable, and offers substantial speed ups.



