### PR TITLE
Remove multiple optimisation passes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tapir"
 uuid = "07d77754-e150-4737-8c94-cd238a1fb45b"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.2.46"
+version = "0.2.47"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -904,8 +904,8 @@ function build_rrule(
                 primal_ir, Treturn, ad_stmts_blocks, pb_comms_insts, info, Tshared_data
             )
 
-            optimised_fwds_ir = optimise_ir!(optimise_ir!(IRCode(fwds_ir); do_inline=true))
-            optimised_pb_ir = optimise_ir!(optimise_ir!(IRCode(pb_ir); do_inline=true))
+            optimised_fwds_ir = optimise_ir!(IRCode(fwds_ir); do_inline=true)
+            optimised_pb_ir = optimise_ir!(IRCode(pb_ir); do_inline=true)
             # optimised_fwds_ir = optimise_ir!(IRCode(fwds_ir); do_inline=false)
             # optimised_pb_ir = optimise_ir!(IRCode(pb_ir); do_inline=true)
             # @show sig_or_mi


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Tapir.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
I currently run multiple optimisation passes, because at some point in the past this was necessary in order to get everything to infer properly. I'm running the test suite to try and figure out if this is still true, or if it's in fact gone away, and we can get away with optimising just once.

If it is, I'll merge this and tag a release, because optimising twice feels 1) silly, and 2) sometimes causes problems during inlining.