### PR TITLE
Fix Caching in ADgradient

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tapir"
 uuid = "07d77754-e150-4737-8c94-cd238a1fb45b"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.2.47"
+version = "0.2.48"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/docs/src/debugging_and_mwes.md
+++ b/docs/src/debugging_and_mwes.md
@@ -26,10 +26,7 @@ end
 For example
 ```julia
 f(x) = Core.bitcast(Float64, x)
-Tapir.TestUtils.test_rule(
-    Random.Xoshiro(123), f, 3;
-    is_primitive=false, perf_flag=:none, interp=Tapir.TapirInterpreter(),
-)
+Tapir.TestUtils.test_rule(Random.Xoshiro(123), f, 3; is_primitive=false)
 ```
 will error.
 (In this particular case, it is caused by Tapir.jl preventing you from doing (potentially) unsafe casting. In this particular instance, Tapir.jl just fails to compile, but in other instances other things can happen.)

--- a/docs/src/known_limitations.md
+++ b/docs/src/known_limitations.md
@@ -131,7 +131,7 @@ function foo(x::Vector{Float64})
     return unsafe_load(p)
 end
 
-rule = build_rrule(Tapir.TapirInterpreter(), Tuple{typeof(foo), Vector{Float64}})
+rule = build_rrule(get_tapir_interpreter(), Tuple{typeof(foo), Vector{Float64}})
 Tapir.value_and_gradient!!(rule, foo, [5.0, 4.0])
 
 # output

--- a/ext/TapirLogDensityProblemsADExt.jl
+++ b/ext/TapirLogDensityProblemsADExt.jl
@@ -34,7 +34,7 @@ Gradient using algorithmic/automatic differentiation via Tapir.
 function ADgradient(::Val{:Tapir}, ℓ; safety_on::Bool=false, rule=nothing)
     if isnothing(rule)
         primal_sig = Tuple{typeof(logdensity), typeof(ℓ), Vector{Float64}}
-        rule = Tapir.build_rrule(Tapir.TapirInterpreter(), primal_sig; safety_on)
+        rule = Tapir.build_rrule(Tapir.get_tapir_interpreter(), primal_sig; safety_on)
     end
     return TapirGradientLogDensity(rule, Tapir.uninit_fcodual(ℓ))
 end

--- a/src/Tapir.jl
+++ b/src/Tapir.jl
@@ -115,6 +115,7 @@ export
     fdata_type,
     rdata_type,
     fdata,
-    rdata
+    rdata,
+    get_tapir_interpreter
 
 end

--- a/src/interpreter/abstract_interpretation.jl
+++ b/src/interpreter/abstract_interpretation.jl
@@ -58,8 +58,8 @@ const GLOBAL_INTERPRETER = Ref(TapirInterpreter())
 
 Returns a `TapirInterpreter` appropriate for the current world age. Will use a cached
 interpreter if one already exists for the current world age, otherwise creates a new one.
-This is a very conservative approach to caching the interpreter, which reflects the
-approach taken the the closure cache.
+
+This should be prefered over constructing a `TapirInterpreter` directly.
 """
 function get_tapir_interpreter()
     if GLOBAL_INTERPRETER[].world != Base.get_world_counter()

--- a/test/chain_rules_macro.jl
+++ b/test/chain_rules_macro.jl
@@ -7,7 +7,5 @@ end
 Tapir.@from_rrule DefaultCtx Tuple{typeof(bleh), Float64, Int}
 
 @testset "chain_rules_macro" begin
-    Tapir.TestUtils.test_rule(
-        Xoshiro(1), bleh, 5.0, 4; perf_flag=:stability, interp=Tapir.TapirInterpreter()
-    )
+    Tapir.TestUtils.test_rule(Xoshiro(1), bleh, 5.0, 4; perf_flag=:stability)
 end

--- a/test/interpreter/s2s_reverse_mode_ad.jl
+++ b/test/interpreter/s2s_reverse_mode_ad.jl
@@ -31,7 +31,7 @@ end
         )
         is_used_dict = Dict{ID, Bool}(id_ssa_1 => true, id_ssa_2 => true)
         rdata_ref = Ref{Tuple{map(Tapir.lazy_zero_rdata_type, (Float64, Int))...}}()
-        info = ADInfo(Tapir.TapirInterpreter(), arg_types, ssa_insts, is_used_dict, false, rdata_ref)
+        info = ADInfo(get_tapir_interpreter(), arg_types, ssa_insts, is_used_dict, false, rdata_ref)
 
         # Verify that we can access the interpreter and terminator block ID.
         @test info.interp isa Tapir.TapirInterpreter
@@ -60,7 +60,7 @@ end
         id_line_1 = ID()
         id_line_2 = ID()
         info = ADInfo(
-            Tapir.TapirInterpreter(),
+            get_tapir_interpreter(),
             Dict{Argument, Any}(Argument(1) => typeof(sin), Argument(2) => Float64),
             Dict{ID, CC.NewInstruction}(
                 id_line_1 => new_inst(Expr(:invoke, nothing, cos, Argument(2)), Float64),
@@ -213,7 +213,7 @@ end
         ],
         safety_on in [true, false]
 
-        interp = Tapir.TapirInterpreter()
+        interp = get_tapir_interpreter()
         rule = Tapir.build_rrule(interp, sig; safety_on)
         @test rule isa Tapir.rule_type(interp, sig; safety_on)
     end


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Tapir.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
I hadn't propagated the way that rule caching happens in a previous PR to `ADgradient`, which meant we were seeing time-outs in the Turing.jl CI. This fixes that.

Sadly, I don't know how to write unit tests for this, so it all feels a little bit fragile. If I think of anything at a later date, I'll add it in to Tapir.jl, but for now I would like to get this merged asap so that Turing.jl's tests pass again.

edit: @yebai this should resolve the problem that we discussed on slack.