### PR TITLE
Fix World Age Problems

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tapir"
 uuid = "07d77754-e150-4737-8c94-cd238a1fb45b"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.2.49"
+version = "0.2.50"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/test/interpreter/s2s_reverse_mode_ad.jl
+++ b/test/interpreter/s2s_reverse_mode_ad.jl
@@ -274,5 +274,11 @@ end
             Xoshiro(123456), S2SGlobals.f, S2SGlobals.A(2 * ones(3)), ones(3);
             interface_only=false, is_primitive=false,
         )
+
+        # BenchmarkTools not working due to world age problems. Provided that this code
+        # runs successfully, everything is okay -- no need to check anything specific.
+        f(x) = sin(cos(x))
+        rule = Tapir.build_rrule(f, 0.0)
+        @benchmark Tapir.value_and_gradient!!($rule, $f, $(Ref(0.0))[])
     end
 end


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Tapir.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
I had introduced some fairly conservative world age checks in a previous PR, the purpose of which was to err on the side of caution, and insist that you only attempt to derive a rule based on the current world age. Unfortunately, this doesn't interact well with BenchmarkTools, because it typically progresses the world age, and you have to have constructed a rule by the time that a call to `@benchmark` is made.

This PR doesn't relax the world age assumption, but does make a point of updating the interpreter more regularly, to prevent it from getting behind.

